### PR TITLE
Bump django version to 1.10.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ python:
 env:
  - DJANGO_VERSION="Django>=1.9,<1.10"
  - DJANGO_VERSION="Django>=1.10,<1.11"
+ - DJANGO_VERSION="Django>=1.11,<2.0"
 install:
   - pip install -r requirements.txt
   - pip install -q $DJANGO_VERSION

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 apipkg==1.4
 coverage==4.2
-Django==1.10.3
+Django==1.10.8
 execnet==1.4.1
 flake8==3.0.4
 isort==4.2.5


### PR DESCRIPTION
We got a security alert from GitHub that required us to upgrade to
Django version to >=1.10.7.

Also added a 1.11.x env to travis.